### PR TITLE
fix: add github-scm-trait-notification-context plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN jenkins-plugin-cli --plugins \
   docker-workflow \
   github-oauth \
   basic-branch-build-strategies \
+  github-scm-trait-notification-context \
   configuration-as-code
 # USER root
 ARG version=unknown


### PR DESCRIPTION
All Jenkins instances use the same name to talk with GitHub and it gives us issues like [this one](https://makingsense.slack.com/archives/CGN03EBDM/p1679424413064269). 

Based on [this discussion](https://issues.jenkins.io/browse/JENKINS-55726?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel), I think that this plugin will help us.