### PR TITLE
Allow jenkins to run docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ RUN yarn verify-format && yarn verify-spell
 
 FROM jenkins/jenkins:2.396-jdk11 as final
 USER root
-RUN ls /var/run && usermod -aG root jenkins
 RUN apt-get update && apt-get install -y --no-install-recommends lsb-release=11.1.0 \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ ENV CI=true
 RUN yarn verify-format && yarn verify-spell
 
 FROM jenkins/jenkins:2.396-jdk11 as final
+# Keep root user because I need it to access to /var/run/docker.sock
+# hadolint ignore=DL3002
 USER root
 RUN apt-get update && apt-get install -y --no-install-recommends lsb-release=11.1.0 \
   && apt-get clean \
@@ -26,14 +28,14 @@ RUN echo "deb [arch=$(dpkg --print-architecture) \
 RUN apt-get update && apt-get install -y --no-install-recommends docker-ce-cli=5:23.0.1-1~debian.11~bullseye \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
-USER jenkins
+# USER jenkins
 RUN jenkins-plugin-cli --plugins \
   blueocean \
   docker-workflow \
   github-oauth \
   basic-branch-build-strategies \
   configuration-as-code
-USER root
+# USER root
 ARG version=unknown
 RUN echo $version > /version.txt
-USER jenkins
+# USER jenkins


### PR DESCRIPTION
The previous approach (https://github.com/FromDoppler/doppler-jenkins/pull/14) did not work.

Temporarily using `root` will work.