### PR TITLE
Install gitlint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,9 @@ FROM jenkins/jenkins:2.396-jdk11 as final
 # Keep root user because I need it to access to /var/run/docker.sock
 # hadolint ignore=DL3002
 USER root
-RUN apt-get update && apt-get install -y --no-install-recommends lsb-release=11.1.0 \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  lsb-release=11.1.0 \
+  gitlint=0.15.0-1 \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 RUN curl -fsSLo /usr/share/keyrings/docker-archive-keyring.asc \


### PR DESCRIPTION
Mapping volumes when running docker in this way does not work in our new Jenkins:

```sh
docker run --ulimit nofile=1024 \
  -v "$(pwd)/.git":/repo/.git \
  -v "$(pwd)/.gitlint":/repo/.gitlint \
  jorisroovers/gitlint:0.18.0 \
  --config /repo/.gitlint \
  --commits origin/main..HEAD
```

It is because the path is relative to the host and not to the Jenkins container ([see this](https://github.com/nestybox/sysbox/issues/146#issuecomment-736676862)).

For that reason, I think that we can install GitLint in the Jenkins image and use it in this way:

```sh
gitlint --config .gitlint --commits origin/main..HEAD
```