### PR TITLE
Restore docker-workflow plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends docker-ce-cli=5
 
 RUN jenkins-plugin-cli --plugins \
   blueocean:1.27.3 \
+  docker-workflow:563.vd5d2e5c4007f \
   github-oauth:0.39 \
   basic-branch-build-strategies:71.vc1421f89888e \
   github-scm-trait-notification-context:1.1 \


### PR DESCRIPTION
We need `docker-workflow` plugin to use `withDockerRegistry`

![image](https://user-images.githubusercontent.com/1157864/228559078-68a4d391-2843-4bea-b2f6-74591cdfb4a3.png)
