### PR TITLE
DE-971 - Compatibility with the new Jenkins

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,7 @@ build
 Dockerfile*
 Jenkinsfile
 .doppler-ci
+doppler-jenkins-ci.groovy
 
 # Allow copying encrypted secrets only (SOPS)
 *.[sS]ecret.*

--- a/.editorconfig
+++ b/.editorconfig
@@ -17,7 +17,7 @@ block_comment_end = */
 max_line_length = 220
 
 # Unset for binary and generated files
-[{**.svg,**.png,**/obj/**,**/bin/**,.vscode/**,**/Properties/launchSettings.json,*.[sS]ecret.*,yarn.lock,.doppler-ci,build/**}]
+[{**.svg,**.png,**/obj/**,**/bin/**,.vscode/**,**/Properties/launchSettings.json,*.[sS]ecret.*,yarn.lock,.doppler-ci,doppler-jenkins-ci.groovy,build/**}]
 charset = unset
 end_of_line = unset
 insert_final_newline = unset

--- a/.prettierignore
+++ b/.prettierignore
@@ -21,7 +21,7 @@ yarn.lock
 package-lock.json
 [eE]ncrypted.[sS]ecret.*
 *.key
-.doppler-ci
+doppler-jenkins-ci.groovy
 /build
 *.env
 *.env.*

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@ pipeline {
                         withDockerRegistry(credentialsId: "${DOCKER_CREDENTIALS_ID}", url: "") {
                             sh '''
                               sh build-n-publish.sh \
-                                --image=${DOCKER_IMAGE_NAME} \
+                                --image=${DOCKER_IMAGE_NAME}${PACKAGE_SUFFIX} \
                                 --commit=${GIT_COMMIT} \
                                 --name=pr-${CHANGE_ID}
                             '''
@@ -60,7 +60,7 @@ pipeline {
                         withDockerRegistry(credentialsId: "${DOCKER_CREDENTIALS_ID}", url: "") {
                             sh '''
                               sh build-n-publish.sh \
-                                --image=${DOCKER_IMAGE_NAME} \
+                                --image=${DOCKER_IMAGE_NAME}${PACKAGE_SUFFIX} \
                                 --commit=${GIT_COMMIT} \
                                 --name=main
                               '''
@@ -75,7 +75,7 @@ pipeline {
                         withDockerRegistry(credentialsId: "${DOCKER_CREDENTIALS_ID}", url: "") {
                             sh '''
                               sh build-n-publish.sh \
-                                --image=${DOCKER_IMAGE_NAME} \
+                                --image=${DOCKER_IMAGE_NAME}${PACKAGE_SUFFIX} \
                                 --commit=${GIT_COMMIT} \
                                 --name=INT
                               '''
@@ -92,7 +92,7 @@ pipeline {
                         withDockerRegistry(credentialsId: "${DOCKER_CREDENTIALS_ID}", url: "") {
                             sh '''
                               sh build-n-publish.sh \
-                                --image=${DOCKER_IMAGE_NAME} \
+                                --image=${DOCKER_IMAGE_NAME}${PACKAGE_SUFFIX} \
                                 --commit=${GIT_COMMIT} \
                                 --version=${TAG_NAME}
                             '''

--- a/doppler-jenkins-ci.groovy
+++ b/doppler-jenkins-ci.groovy
@@ -1,0 +1,1 @@
+Jenkinsfile

--- a/gitlint.sh
+++ b/gitlint.sh
@@ -20,9 +20,13 @@ export MSYS2_ARG_CONV_EXCL="*"
 
 # See more information in https://jorisroovers.com/gitlint
 
-docker run --ulimit nofile=1024 \
-  -v "$(pwd)/.git":/repo/.git \
-  -v "$(pwd)/.gitlint":/repo/.gitlint \
-  jorisroovers/gitlint:0.18.0 \
-  --config /repo/.gitlint \
-  --commits origin/main..HEAD
+if [ -x "$(command -v gitlint)" ]; then
+  gitlint --config .gitlint --commits origin/main..HEAD
+else
+  docker run --ulimit nofile=1024 \
+    -v "$(pwd)/.git":/repo/.git \
+    -v "$(pwd)/.gitlint":/repo/.gitlint \
+    jorisroovers/gitlint:0.18.0 \
+    --config /repo/.gitlint \
+    --commits origin/main..HEAD
+fi


### PR DESCRIPTION
Related to https://github.com/FromDoppler/doppler-system-usage/pull/81, https://github.com/FromDoppler/doppler-webapp/pull/2271, https://github.com/FromDoppler/doppler-html-editor-api/pull/232 and https://github.com/FromDoppler/doppler-editors-webapp/pull/491

- Adding a suffix (_empty string_ in the old Jenkins and `-new` in the new Jenkins) to the generated asset-manifest files. It allows pushing the files to CDN without collisions with the official ones.

- Using builtin gitlint or dockerized version depending on availability

-  Adding a new symlink `doppler-jenkins-ci.groovy` to identify that the new Jenkins should listen to this repository.
