### PR TITLE
DE-971 - Remove buildx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN echo "deb [arch=$(dpkg --print-architecture) \
   https://download.docker.com/linux/debian \
   $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    docker-ce-cli=5:23.0.1-1~debian.11~bullseye \
+    docker-ce-cli=5:23.0.2-1~debian.11~bullseye \
     docker-buildx-plugin=0.10.4-1~debian.11~bullseye \
     docker-compose-plugin=2.17.2-1~debian.11~bullseye \
   && apt-get clean \

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,11 +34,15 @@ RUN echo "deb [arch=$(dpkg --print-architecture) \
   $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
 RUN apt-get update && apt-get install -y --no-install-recommends \
     docker-ce-cli=5:23.0.2-1~debian.11~bullseye \
-    docker-buildx-plugin=0.10.4-1~debian.11~bullseye \
     docker-compose-plugin=2.17.2-1~debian.11~bullseye \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && ln -s /usr/libexec/docker/cli-plugins/docker-compose /usr/bin/docker-compose
+# TODO: also install docker-buildx-plugin
+# Right now, it is not installed because it confuses symlinks with folders and
+# break with commands like `COPY ./**/*.sh ./`.
+# See https://github.com/FromDoppler/doppler-html-editor-api/pull/232/files#r1156481727
+
 # USER jenkins
 
 RUN jenkins-plugin-cli --plugins \


### PR DESCRIPTION
Finally, I decided to remove buildx because it is breaking many builds.

I tested all available docker versions for Debian Bulleye and also tested [different backends](https://hub.docker.com/r/docker/dockerfile/tags), from the older to the newer with the same result.